### PR TITLE
v1.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: php
+
+php:
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - hhvm

--- a/src/FacturaeItem.php
+++ b/src/FacturaeItem.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace josemmo\Facturae;
+
+/**
+ * Facturae Item
+ *
+ * Represents an invoice item
+ */
+class FacturaeItem {
+  private $name = NULL;
+  private $description = NULL;
+  private $quantity = 1;
+  private $unitPrice = NULL;
+  private $unitPriceWithoutTax = NULL;
+  private $taxes = array();
+
+  private $totalAmountWithoutTax = NULL;   // $quantity * $unitPriceWithoutTax
+  private $grossAmount = NULL; // For now, $grossAmount = $totalAmountWithoutTax
+  private $taxAmount = NULL;
+  private $totalAmount = NULL; // $totalAmountWithoutTax + $taxAmount
+
+
+  /**
+   * Construct
+   * @param array $properties Item properties as an array
+   */
+  public function __construct($properties=array()) {
+    foreach ($properties as $key=>$value) $this->{$key} = $value;
+
+    // Normalize taxes array
+    foreach ($this->taxes as $r=>$tax) {
+      if (!is_array($tax)) $this->taxes[$r] = array("rate"=>$tax, "amount"=>0);
+    }
+
+    // Calculate unit and total amount without tax
+    if (is_null($this->unitPriceWithoutTax)) {
+      $percent = 1;
+      if (isset($this->taxes[Facturae::TAX_IVA])) $percent +=
+        $this->taxes[Facturae::TAX_IVA]['rate'] / 100;
+      if (isset($this->taxes[Facturae::TAX_IRPF])) $percent -=
+        $this->taxes[Facturae::TAX_IRPF]['rate'] / 100;
+      $this->unitPriceWithoutTax = $this->unitPrice / $percent;
+    }
+    $this->totalAmountWithoutTax = $this->unitPriceWithoutTax * $this->quantity;
+
+    // Calculate tax amount
+    $this->taxAmount = 0;
+    foreach ($this->taxes as $type=>$tax) {
+      $this->taxes[$type]['amount'] = $this->totalAmountWithoutTax *
+        ($tax['rate'] / 100);
+      $this->taxAmount += $this->taxes[$type]['amount'];
+    }
+
+    // Calculate rest of values
+    $this->grossAmount = $this->totalAmountWithoutTax;
+    $this->totalAmount = $this->totalAmountWithoutTax + $this->taxAmount;
+  }
+
+
+  /**
+   * Get data
+   *
+   * @return array Item data
+   */
+  public function getData() {
+    return get_object_vars($this);
+  }
+
+}

--- a/tests/FacturaeTest.php
+++ b/tests/FacturaeTest.php
@@ -1,8 +1,9 @@
-<?php 
+<?php
 
-require_once __DIR__ . '/../vendor/autoload.php'; // Autoload files using Composer autoload
+require_once __DIR__ . '/../vendor/autoload.php';
 
 use josemmo\Facturae\Facturae;
+use josemmo\Facturae\FacturaeItem;
 use josemmo\Facturae\FacturaeParty;
 
 // Creamos la factura
@@ -43,12 +44,36 @@ $fac->setBuyer(new FacturaeParty([
 
 // Añadimos los productos a incluir en la factura
 // En este caso, probaremos con tres lámpara por
-// precio unitario de 20,14€ + 21% IVA
+// precio unitario de 20,14€, IVA al 21% YA INCLUÍDO
 $fac->addItem("Lámpara de pie", 20.14, 3, Facturae::TAX_IVA, 21);
 
+// Y ahora, una línea con IVA al 0%
+$fac->addItem("Algo exento de IVA", 100, 1, Facturae::TAX_IVA, 0);
+
+// Vamos a añadir un producto utilizando la API avanzada
+// que tenga IVA al 10% e IRPF al 15%
+$fac->addItem(new FacturaeItem([
+  "name" => "Una línea con varios impuestos",
+  "description" => "Esta línea es solo para probar Facturae-PHP",
+  "quantity" => 1, // Esto es opcional, es el valor por defecto si se omite
+  "unitPrice" => 43.64,
+  "taxes" => array(
+    Facturae::TAX_IVA  => 10,
+    Facturae::TAX_IRPF => 15
+  )
+]));
+
+// Para terminar, añadimos 3 bombillas LED con un coste de 6,50 € ...
+// ... pero con los impuestos NO INCLUÍDOS en el precio unitario
+$fac->addItem(new FacturaeItem([
+  "name" => "Bombilla LED",
+  "quantity" => 3,
+  "unitPriceWithoutTax" => 6.5, // NOTA: no confundir con unitPrice
+  "taxes" => array(Facturae::TAX_IVA => 21)
+]));
+
 // Ya solo queda firmar la factura ...
-$fac->sign(__DIR__ . "/public.pem",
-  __DIR__ . "/private.pem", "12345");
+$fac->sign(__DIR__ . "/public.pem", __DIR__ . "/private.pem", "12345");
 
 // ... y exportarlo a un archivo
 $fac->export(__DIR__ . "/salida.xsig");


### PR DESCRIPTION
Añadida API avanzada de productos (clase `FacturaeItem`) que permite:
 - Establecer importe unitario sin impuestos (base imponible)
 - Múltiples impuestos por producto (IVA + IRPF)

> NOTA IMPORTANTE
> Se ha cambiado la salida del método `Facturae::getTotals()` para adaptarlo a la nueva API