### PR TITLE
Add PKCS#12 Certificate Store support

### DIFF
--- a/src/Facturae.php
+++ b/src/Facturae.php
@@ -440,7 +440,7 @@ class Facturae {
     $this->signatureSignedPropertiesID = $this->random();
     $this->signatureObjectID = $this->random();
     
-    return load_pkcs12($pkcs12_file, $pkcs12_pass);
+    return $this->load_pkcs12($pkcs12_file, $pkcs12_pass);
   }
 
 

--- a/src/Facturae.php
+++ b/src/Facturae.php
@@ -415,7 +415,7 @@ class Facturae {
     $this->signatureSignedPropertiesID = $this->random();
     $this->signatureObjectID = $this->random();
     
-    return $this->loadx509($publicPath, $privatePath, $passphrase);
+    return $this->load_x509($publicPath, $privatePath, $passphrase);
   }
 
 

--- a/src/Facturae.php
+++ b/src/Facturae.php
@@ -104,7 +104,11 @@ class Facturae {
    * @return int  Random number
    */
   private function random() {
-    return rand(100000, 999999);
+    if (function_exists('random_int')) {
+      return random_int(0x10000000, 0x7FFFFFFF);
+    } else {
+      return rand(100000, 999999);
+    }
   }
 
 
@@ -348,17 +352,57 @@ class Facturae {
 
 
   /**
+   * Load a PKCS#12 Certificate Store
+   *
+   * @param  string $pkcs12_file  The certificate store file name
+   * @param  string $pkcs12_pass  Encryption password for unlocking the PKCS#12 file
+   * @return bool  true on success or FALSE on failure.
+   */
+  public function load_pkcs12 ($pkcs12_file, $pkcs12_pass) {
+    $this->publicKey = null;
+    $this->privateKey = null;
+
+    if (is_file($pkcs12_file) and !empty($pkcs12_pass)) {
+      if (openssl_pkcs12_read(file_get_contents($pkcs12_file), $certs, $pkcs12_pass)) {
+        $this->publicKey = $certs['cert'];
+        $this->privateKey = openssl_pkey_get_private($certs['pkey']);
+      }
+    }
+
+    return (!empty($this->publicKey) and !empty($this->privateKey));
+  }
+
+  /**
+   * Load a X.509 certificate and PEM encoded private key 
+   *
+   * @param  string $publicPath  Path to public key PEM file
+   * @param  string $privatePath Path to private key PEM file
+   * @param  string $passphrase  Private key passphrase
+   * @return bool  true on success or FALSE on failure.
+   */
+  public function load_x509 ($publicPath, $privatePath, $passphrase = '') {
+    $this->publicKey = null;
+    $this->privateKey = null;
+
+    if (is_file($publicPath) and is_file($privatePath)) {
+      $this->publicKey = openssl_x509_read(file_get_contents($publicPath));
+      $this->privateKey = openssl_pkey_get_private(file_get_contents($privatePath), $passphrase);
+    }
+
+    return (!empty($this->publicKey) and !empty($this->privateKey));
+  }
+
+
+  /**
    * Sign
    *
    * @param  string $publicPath  Path to public key PEM file
    * @param  string $privatePath Path to private key PEM file
    * @param  string $passphrase  Private key passphrase
    * @param  array  $policy      Facturae sign policy
+   * @return bool  true on success or FALSE on failure.
    */
   public function sign($publicPath, $privatePath, $passphrase, $policy=self::SIGN_POLICY_3_1) {
-    $this->publicKey = openssl_x509_read(file_get_contents($publicPath));
-    $this->privateKey = openssl_pkey_get_private(
-      file_get_contents($privatePath), $passphrase);
     $this->signPolicy = $policy;
 
     // Generate random IDs
@@ -370,6 +414,33 @@ class Facturae {
     $this->referenceID = $this->random();
     $this->signatureSignedPropertiesID = $this->random();
     $this->signatureObjectID = $this->random();
+    
+    return $this->loadx509($publicPath, $privatePath, $passphrase);
+  }
+
+
+  /**
+   * Sign with PKCS#12 Certificate Store
+   *
+   * @param  string $pkcs12_file  The certificate store file name
+   * @param  string $pkcs12_pass  Encryption password for unlocking the PKCS#12 file
+   * @param  array  $policy      Facturae sign policy
+   * @return bool  true on success or FALSE on failure.
+   */
+  public function sign_pkcs12($pkcs12_file, $pkcs12_pass, $policy=self::SIGN_POLICY_3_1) {
+    $this->signPolicy = $policy;
+
+    // Generate random IDs
+    $this->signatureID = $this->random();
+    $this->signedInfoID = $this->random();
+    $this->signedPropertiesID = $this->random();
+    $this->signatureValueID = $this->random();
+    $this->certificateID = $this->random();
+    $this->referenceID = $this->random();
+    $this->signatureSignedPropertiesID = $this->random();
+    $this->signatureObjectID = $this->random();
+    
+    return load_pkcs12($pkcs12_file, $pkcs12_pass);
   }
 
 
@@ -386,20 +457,23 @@ class Facturae {
     $xml = str_replace("\r", "", $xml);
 
     // Define namespace
-    $xmlns = 'xmlns:ds="http://www.w3.org/2000/09/xmldsig#" ' .
-      'xmlns:etsi="http://uri.etsi.org/01903/v1.3.2#" ' .
-      'xmlns:fe="http://www.facturae.es/Facturae/2014/v' .
-      $this->version . '/Facturae"';
+    $xmlns = null;
+    $xmlns .= 'xmlns:ds="http://www.w3.org/2000/09/xmldsig#" ';
+    $xmlns .= 'xmlns:xades="http://uri.xades.org/01903/v1.3.2#" ';
+    $xmlns .= 'xmlns:fe="http://www.facturae.es/Facturae/2014/v' . $this->version . '/Facturae"';
 
     // Prepare signed properties
     $signTime = is_null($this->signTime) ? time() : $this->signTime;
+
     $certData = openssl_x509_parse($this->publicKey);
-    $certDigest = openssl_x509_fingerprint($this->publicKey, "sha1", true);
+    $certDigest = openssl_x509_fingerprint($this->publicKey, 'sha1', true);
     $certDigest = base64_encode($certDigest);
-    $certIssuer = "CN=" . $certData['issuer']['CN'] . "," .
-                  "OU=" . $certData['issuer']['OU'] . "," .
-                  "O=" .  $certData['issuer']['O']  . "," .
-                  "C=" .  $certData['issuer']['C'];
+
+    foreach (['CN', 'OU', 'O', 'C'] as $item) {
+      $certIssuer[] = $item . '=' . $certData['issuer'][$item];
+    }
+    $certIssuer = implode(',', $certIssuer);
+    
     $prop = '<etsi:SignedProperties Id="Signature' . $this->signatureID .
       '-SignedProperties' . $this->signatureSignedPropertiesID . '">' .
       '<etsi:SignedSignatureProperties><etsi:SigningTime>' .

--- a/src/Facturae.php
+++ b/src/Facturae.php
@@ -364,7 +364,7 @@ class Facturae {
 
     if (is_file($pkcs12_file) and !empty($pkcs12_pass)) {
       if (openssl_pkcs12_read(file_get_contents($pkcs12_file), $certs, $pkcs12_pass)) {
-        $this->publicKey = $certs['cert'];
+        $this->publicKey = openssl_x509_read($certs['cert']);
         $this->privateKey = openssl_pkey_get_private($certs['pkey']);
       }
     }


### PR DESCRIPTION
Added support for certificates in PKCS # 12 format (p12, pfx)
Use of random_int if available.
Reformatting the definition of the namespace
Refactoring the generation of $ certIssuer

Se añade soporte para certificados en formato PKCS#12 (p12, pfx)
Utilización de random_int si está disponible.
Reformateo de la definición del namespace.
Refactorización de la generación de $certIssuer.