### PR TITLE
Agregar soporte para añadir retenciones a la factura

### DIFF
--- a/src/Controller/FacturaeExportable.php
+++ b/src/Controller/FacturaeExportable.php
@@ -155,6 +155,15 @@ abstract class FacturaeExportable extends FacturaeSignable {
     $xml .= '<TotalTaxesWithheld>' . $totals['totalTaxesWithheld'] . '</TotalTaxesWithheld>';
     $xml .= '<InvoiceTotal>' . $totals['invoiceAmount'] . '</InvoiceTotal>';
     $xml .= '<TotalOutstandingAmount>' . $totals['invoiceAmount'] . '</TotalOutstandingAmount>';
+    if (!empty($totals['amountsWithheld'])) {
+      $xml .= '<AmountsWithheld>';
+      foreach ($totals['amountsWithheld'][] as $item) {
+        $xml .= '<WithholdingReason>' . $item['reason']. '</WithholdingReason>';        
+        $xml .= '<WithholdingAmount>' . $item['amount']. '</WithholdingAmount>';        
+      }
+      $xml .= '</AmountsWithheld>';
+    }
+    
     $xml .= '<TotalExecutableAmount>' . $totals['invoiceAmount'] . '</TotalExecutableAmount>';
     $xml .= '</InvoiceTotals>';
 

--- a/src/Controller/FacturaeExportable.php
+++ b/src/Controller/FacturaeExportable.php
@@ -157,14 +157,16 @@ abstract class FacturaeExportable extends FacturaeSignable {
     $xml .= '<TotalOutstandingAmount>' . $totals['invoiceAmount'] . '</TotalOutstandingAmount>';
     if (!empty($totals['amountsWithheld'])) {
       $xml .= '<AmountsWithheld>';
-      foreach ($totals['amountsWithheld'][] as $item) {
+      $amountWithheld = 0;
+      foreach ($totals['amountsWithheld'] as $item) {
         $xml .= '<WithholdingReason>' . $item['reason']. '</WithholdingReason>';        
-        $xml .= '<WithholdingAmount>' . $item['amount']. '</WithholdingAmount>';        
+        $xml .= '<WithholdingAmount>' . $item['amount']. '</WithholdingAmount>';
+        $amountWithheld += $item['amount'];
       }
       $xml .= '</AmountsWithheld>';
     }
     
-    $xml .= '<TotalExecutableAmount>' . $totals['invoiceAmount'] . '</TotalExecutableAmount>';
+    $xml .= '<TotalExecutableAmount>' . ($totals['invoiceAmount'] - $amountWithheld) . '</TotalExecutableAmount>';
     $xml .= '</InvoiceTotals>';
 
     // Add invoice items

--- a/src/Controller/FacturaeExportable.php
+++ b/src/Controller/FacturaeExportable.php
@@ -62,7 +62,7 @@ abstract class FacturaeExportable extends FacturaeSignable {
                   '<TotalAmount>' . $totals['invoiceAmount'] . '</TotalAmount>' .
                 '</TotalOutstandingAmount>' .
                 '<TotalExecutableAmount>' .
-                  '<TotalAmount>' . $totals['invoiceAmount'] . '</TotalAmount>' .
+                  '<TotalAmount>' . $totals['executableAmount'] . '</TotalAmount>' .
                 '</TotalExecutableAmount>' .
                 '<InvoiceCurrencyCode>' . $this->currency . '</InvoiceCurrencyCode>' .
               '</Batch>' .
@@ -157,16 +157,14 @@ abstract class FacturaeExportable extends FacturaeSignable {
     $xml .= '<TotalOutstandingAmount>' . $totals['invoiceAmount'] . '</TotalOutstandingAmount>';
     if (!empty($totals['amountsWithheld'])) {
       $xml .= '<AmountsWithheld>';
-      $amountWithheld = 0;
       foreach ($totals['amountsWithheld'] as $item) {
         $xml .= '<WithholdingReason>' . $item['reason']. '</WithholdingReason>';        
         $xml .= '<WithholdingAmount>' . $item['amount']. '</WithholdingAmount>';
-        $amountWithheld += $item['amount'];
       }
       $xml .= '</AmountsWithheld>';
     }
     
-    $xml .= '<TotalExecutableAmount>' . ($totals['invoiceAmount'] - $amountWithheld) . '</TotalExecutableAmount>';
+    $xml .= '<TotalExecutableAmount>' . $totals['executableAmount'] . '</TotalExecutableAmount>';
     $xml .= '</InvoiceTotals>';
 
     // Add invoice items

--- a/src/Controller/FacturaeProperties.php
+++ b/src/Controller/FacturaeProperties.php
@@ -566,7 +566,7 @@ abstract class FacturaeProperties extends FacturaeConstants {
       }
     }
     
-    foreach ($amountsWithheld as $item){
+    foreach ($this->amountsWithheld as $item){
       $totals['amountsWithheld'][] = array(
         "reason" => $item['reason'],
         "amount" => pad($item['amount'])

--- a/src/Controller/FacturaeProperties.php
+++ b/src/Controller/FacturaeProperties.php
@@ -37,6 +37,7 @@ abstract class FacturaeProperties extends FacturaeConstants {
   );
   protected $items = array();
   protected $legalLiterals = array();
+  protected $amountWithheld = array();
   protected $discounts = array();
   protected $charges = array();
 
@@ -353,8 +354,7 @@ abstract class FacturaeProperties extends FacturaeConstants {
     $this->legalLiterals = array();
     return $this;
   }
-
-
+  
   /**
    * Add general discount
    * @param  string   $reason       Discount reason
@@ -370,7 +370,6 @@ abstract class FacturaeProperties extends FacturaeConstants {
     );
     return $this;
   }
-
 
   /**
    * Get general discounts
@@ -391,6 +390,28 @@ abstract class FacturaeProperties extends FacturaeConstants {
   }
 
 
+  /**
+   * Add amount withheld
+   * @param  string   $reason       Amount withheld reason
+   * @param  float    $value        Amount withheld
+   * @return Facturae               Invoice instance
+   */
+  public function addAmountWithheld($reason, $value) {
+    $this->amountWithheld[] = array(
+      "reason" => $reason,      
+      "amount" => $value
+    );
+    return $this;
+  }
+
+  /**
+   * Get amounts withheld
+   * @return string[] amount withheld
+   */
+  public function getLegalLiterals() {
+    return $this->amountWithheld;
+  }
+  
   /**
    * Add general charge
    * @param  string   $reason       Charge reason

--- a/src/Controller/FacturaeProperties.php
+++ b/src/Controller/FacturaeProperties.php
@@ -567,7 +567,7 @@ abstract class FacturaeProperties extends FacturaeConstants {
     }
     
     foreach ($amountsWithheld as $item){
-      $totals[amountsWithheld][] = array(
+      $totals['amountsWithheld'][] = array(
         "reason" => $item['reason'],
         "amount" => pad($item['amount'])
       );

--- a/src/Controller/FacturaeProperties.php
+++ b/src/Controller/FacturaeProperties.php
@@ -511,7 +511,7 @@ abstract class FacturaeProperties extends FacturaeConstants {
       "generalCharges" => array(),
       "amountsWithheld" => array(),
       "invoiceAmount" => 0, // Total invoice non-inclusive of any amount withheld
-      "executableAmount => 0, // Total invoice amount - amount withheld
+      "executableAmount" => 0, // Total invoice amount - amount withheld
       "grossAmount" => 0,
       "totalGeneralDiscounts" => 0,
       "totalGeneralCharges" => 0,

--- a/src/Controller/FacturaeProperties.php
+++ b/src/Controller/FacturaeProperties.php
@@ -37,7 +37,7 @@ abstract class FacturaeProperties extends FacturaeConstants {
   );
   protected $items = array();
   protected $legalLiterals = array();
-  protected $amountWithheld = array();
+  protected $amountsWithheld = array();
   protected $discounts = array();
   protected $charges = array();
 
@@ -397,7 +397,7 @@ abstract class FacturaeProperties extends FacturaeConstants {
    * @return Facturae               Invoice instance
    */
   public function addAmountWithheld($reason, $value) {
-    $this->amountWithheld[] = array(
+    $this->amountsWithheld[] = array(
       "reason" => $reason,      
       "amount" => $value
     );
@@ -409,7 +409,7 @@ abstract class FacturaeProperties extends FacturaeConstants {
    * @return string[] amount withheld
    */
   public function getAmountsWithheld() {
-    return $this->amountWithheld;
+    return $this->amountsWithheld;
   }
   
   /**

--- a/src/Controller/FacturaeProperties.php
+++ b/src/Controller/FacturaeProperties.php
@@ -510,7 +510,8 @@ abstract class FacturaeProperties extends FacturaeConstants {
       "generalDiscounts" => array(),
       "generalCharges" => array(),
       "amountsWithheld" => array(),
-      "invoiceAmount" => 0,
+      "invoiceAmount" => 0, // Total invoice non-inclusive of any amount withheld
+      "executableAmount => 0, // Total invoice amount - amount withheld
       "grossAmount" => 0,
       "totalGeneralDiscounts" => 0,
       "totalGeneralCharges" => 0,
@@ -566,10 +567,12 @@ abstract class FacturaeProperties extends FacturaeConstants {
       }
     }
     
+    $amountWithheld = 0;
     foreach ($this->amountsWithheld as $item){
       $totals['amountsWithheld'][] = array(
         "reason" => $item['reason'],
         "amount" => pad($item['amount'])
+        $amountWithheld += $item['amount'];
       );
     }
 
@@ -584,6 +587,7 @@ abstract class FacturaeProperties extends FacturaeConstants {
       $totals['totalGeneralDiscounts'] + $totals['totalGeneralCharges']);
     $totals['invoiceAmount'] = $this->pad($totals['grossAmountBeforeTaxes'] +
       $totals['totalTaxesOutputs'] - $totals['totalTaxesWithheld']);
+    $totals['invoiceAmount'] = $totals['invoiceAmount'] - $amountWithheld; 
 
     return $totals;
   }

--- a/src/Controller/FacturaeProperties.php
+++ b/src/Controller/FacturaeProperties.php
@@ -587,7 +587,10 @@ abstract class FacturaeProperties extends FacturaeConstants {
       $totals['totalGeneralDiscounts'] + $totals['totalGeneralCharges']);
     $totals['invoiceAmount'] = $this->pad($totals['grossAmountBeforeTaxes'] +
       $totals['totalTaxesOutputs'] - $totals['totalTaxesWithheld']);
-    $totals['invoiceAmount'] = $totals['invoiceAmount'] - $amountWithheld; 
+    $totals['invoiceAmount'] = $totals['invoiceAmount'] - $amountWithheld;     
+    $totals['executableAmount'] = $totals['invoiceAmount'] - $amountWithheld;
+
+
 
     return $totals;
   }

--- a/src/Controller/FacturaeProperties.php
+++ b/src/Controller/FacturaeProperties.php
@@ -509,6 +509,7 @@ abstract class FacturaeProperties extends FacturaeConstants {
       "taxesWithheld" => array(),
       "generalDiscounts" => array(),
       "generalCharges" => array(),
+      "amountsWithheld" => array(),
       "invoiceAmount" => 0,
       "grossAmount" => 0,
       "totalGeneralDiscounts" => 0,
@@ -563,6 +564,13 @@ abstract class FacturaeProperties extends FacturaeConstants {
         );
         $totals['totalGeneral' . ucfirst($groupTag)] += $amount;
       }
+    }
+    
+    foreach ($amountsWithheld as $item){
+      $totals[amountsWithheld][] = array(
+        "reason" => $item['reason'],
+        "amount" => pad($item['amount'])
+      );
     }
 
     // Normalize rest of values

--- a/src/Controller/FacturaeProperties.php
+++ b/src/Controller/FacturaeProperties.php
@@ -572,8 +572,8 @@ abstract class FacturaeProperties extends FacturaeConstants {
       $totals['amountsWithheld'][] = array(
         "reason" => $item['reason'],
         "amount" => pad($item['amount'])
-        $amountWithheld += $item['amount'];
       );
+      $amountWithheld += $item['amount'];
     }
 
     // Normalize rest of values

--- a/src/Controller/FacturaeProperties.php
+++ b/src/Controller/FacturaeProperties.php
@@ -571,7 +571,7 @@ abstract class FacturaeProperties extends FacturaeConstants {
     foreach ($this->amountsWithheld as $item){
       $totals['amountsWithheld'][] = array(
         "reason" => $item['reason'],
-        "amount" => pad($item['amount'])
+        "amount" => $this->pad($item['amount'])
       );
       $amountWithheld += $item['amount'];
     }

--- a/src/Controller/FacturaeProperties.php
+++ b/src/Controller/FacturaeProperties.php
@@ -408,7 +408,7 @@ abstract class FacturaeProperties extends FacturaeConstants {
    * Get amounts withheld
    * @return string[] amount withheld
    */
-  public function getLegalLiterals() {
+  public function getAmountsWithheld() {
     return $this->amountWithheld;
   }
   


### PR DESCRIPTION
Se modifican los ficheros FacturaeProperties.php y FacturaeExportable.php para añadir en los totales un array que represente las retenciones (no de impuestos). Además se diferencia entre el total de la factura y el total de la factura después de retenciones (TotalExecutableAmount)