### PR TITLE
Agregados los decimales para la versión 3.2.1

### DIFF
--- a/src/Facturae.php
+++ b/src/Facturae.php
@@ -132,6 +132,18 @@ class Facturae {
       "Item/GrossAmount" => ["min"=>6, "max"=>6],
       "Discount/Rate" => ["min"=>4, "max"=>4],
       "Discount/Amount" => ["min"=>6, "max"=>6]
+    ],
+    self::SCHEMA_3_2_1 => [
+      null => ["min"=>2, "max"=>2],
+      "Item/Quantity" => ["min"=>1, "max"=>8], 
+      "Item/TotalAmountWithoutTax" => ["min"=>1, "max"=>8],
+      "Item/UnitPriceWithoutTax" => ["min"=>1, "max"=>8],
+      "Item/GrossAmount" => ["min"=>1, "max"=>8],
+      "Discount/Rate" => ["min"=>1, "max"=>8],
+      "Discount/Amount" => ["min"=>1, "max"=>8],
+      "Tax/Rate" => ["min"=>1, "max"=>8],
+      "Tax/Amount" => ["min"=>1, "max"=>8],
+      "Tax/Base" => ["min"=>1, "max"=>8]
     ]
   );
 


### PR DESCRIPTION
Agrega las cantidades de decimales para la versión 3.2.1, principalmente para los campos `Item/TotalAmountWithoutTax`, `Tax/Amount` y `Tax/Base` que no están definidos en los valores por defecto.

Habría que tener en cuenta dos puntos:
- En verdad el `Item/Quantity` es realmente un double sin restricciones.
- Realmente el mínimo según el esquema es 0 decimales sin el punto decimal, pero la función de `pad()` no es compatible con eso, una posible mejora sería cambiar la función para que quitara el punto si es lo último que queda.

Fixes #56