### PR TITLE
Improve assertions and phpunit executing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
 
 # Run PHPUnit tests
 script:
-  - php vendor/bin/phpunit --coverage-clover build/coverage/xml
+  - XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-clover build/coverage/xml
 
 # Send coverage to Codacy (just once per build)
 after_success:

--- a/tests/InvoiceTest.php
+++ b/tests/InvoiceTest.php
@@ -7,7 +7,7 @@ use josemmo\Facturae\FacturaeItem;
 use josemmo\Facturae\FacturaeParty;
 use josemmo\Facturae\FacturaeCentre;
 
-final class FacturaeTest extends AbstractTest {
+final class InvoiceTest extends AbstractTest {
 
   const FILE_PATH = self::OUTPUT_DIR . "/salida-*.xsig";
 

--- a/tests/MethodsTest.php
+++ b/tests/MethodsTest.php
@@ -76,8 +76,8 @@ final class MethodsTest extends AbstractTest {
     $fac->addCharge('First', 20);
     $fac->addCharge('Second', 25, false);
     $fac->addCharge('Third', 30);
-    $this->assertEquals(2, count($fac->getDiscounts()));
-    $this->assertEquals(3, count($fac->getCharges()));
+    $this->assertCount(2, $fac->getDiscounts());
+    $this->assertCount(3, $fac->getCharges());
     $fac->clearDiscounts();
     $this->assertEquals([], $fac->getDiscounts());
     $fac->clearCharges();

--- a/tests/WebservicesTest.php
+++ b/tests/WebservicesTest.php
@@ -55,10 +55,10 @@ final class WebservicesTest extends AbstractTest {
     $face->setProduction(false);
 
     // Test misc. methods
-    $this->assertFalse(empty($face->getStatus()->estados));
-    $this->assertFalse(empty($face->getAdministrations()->administraciones));
-    $this->assertFalse(empty($face->getUnits('E04921501')->relaciones));
-    $this->assertFalse(empty($face->getNifs('E04921501')->nifs));
+    $this->assertNotEmpty($face->getStatus()->estados);
+    $this->assertNotEmpty($face->getAdministrations()->administraciones);
+    $this->assertNotEmpty($face->getUnits('E04921501')->relaciones);
+    $this->assertNotEmpty($face->getNifs('E04921501')->nifs);
 
     // Generate invoice
     $fac = $this->getWsBaseInvoice();
@@ -94,13 +94,13 @@ final class WebservicesTest extends AbstractTest {
     $invoiceFile->loadData($fac->export(), "factura-de-prueba.xsig");
     $res = $face->sendInvoice(self::NOTIFICATIONS_EMAIL, $invoiceFile);
     $this->assertEquals(intval($res->resultado->codigo), 0);
-    $this->assertFalse(empty($res->factura->numeroRegistro));
+    $this->assertNotEmpty($res->factura->numeroRegistro);
 
     // Cancel invoice
     $res = $face->cancelInvoice($res->factura->numeroRegistro,
       "Factura de prueba autogenerada por " . Facturae::USER_AGENT);
     $this->assertEquals(intval($res->resultado->codigo), 0);
-    $this->assertFalse(empty($res->factura->mensaje));
+    $this->assertNotEmpty($res->factura->mensaje);
 
     // Get invoice status
     $res = $face->getInvoices($res->factura->numeroRegistro);
@@ -118,7 +118,7 @@ final class WebservicesTest extends AbstractTest {
     $faceb2b->setProduction(false);
 
     // Test misc. methods
-    $this->assertFalse(empty($faceb2b->getCodes()->codes));
+    $this->assertNotEmpty($faceb2b->getCodes()->codes);
     $this->assertEquals(intval($faceb2b->getRegisteredInvoices()->resultStatus->code), 0);
     $this->assertEquals(intval($faceb2b->getInvoiceCancellations()->resultStatus->code), 0);
 
@@ -143,7 +143,7 @@ final class WebservicesTest extends AbstractTest {
     $invoiceFile->loadData($fac->export(), "factura-de-prueba.xsig");
     $res = $faceb2b->sendInvoice($invoiceFile);
     $this->assertEquals(intval($res->resultStatus->code), 0);
-    $this->assertFalse(empty($res->invoiceDetail->registryNumber));
+    $this->assertNotEmpty($res->invoiceDetail->registryNumber);
     $registryNumber = $res->invoiceDetail->registryNumber;
 
     // Cancel invoice


### PR DESCRIPTION
# Changed log

- Improve PHPUnit assertions.
- Letting class name be same as PHP file name.
- Adding the `XDEBUG_MODE=coverage` for `vendor/bin/phpunit` command. And fix following message:

```
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.

Code coverage needs to be enabled in php.ini by setting 'xdebug.mode' to 'coverage'
```