### PR TITLE
Corregida la compatibilidad con versiones modernas de PHP.

### DIFF
--- a/src/Common/XmlTools.php
+++ b/src/Common/XmlTools.php
@@ -30,7 +30,7 @@ class XmlTools {
    * @return string        Escaped input
    */
   public static function escape($value) {
-    return htmlspecialchars($value, ENT_XML1, 'UTF-8');
+    return htmlspecialchars($value ?? '', ENT_XML1, 'UTF-8');
   }
 
 


### PR DESCRIPTION
Soluciona el aviso: PHP Deprecated:  htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/Plugins/Facturae/vendor/josemmo/facturae-php/src/Common/XmlTools.php on line 33